### PR TITLE
Precomputing inverse of covariance matrix for faster MDSC and small bugfixes

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -489,20 +489,20 @@ class NC(Coverage):
 class KMNC(Coverage):
     def init_variable(self, hyper):
         assert hyper is not None
-        self.k = hyper
+        self.k = int(hyper)
         self.name = 'KMNC'
         self.range_dict = {}
         coverage_multisec_dict = {}
         for (layer_name, layer_size) in self.layer_size_dict.items():
             num_neuron = layer_size[0]
-            coverage_multisec_dict[layer_name] = torch.zeros((num_neuron, k + 1)).type(torch.BoolTensor).to(self.device)
+            coverage_multisec_dict[layer_name] = torch.zeros((num_neuron, self.k + 1)).type(torch.BoolTensor).to(self.device)
             self.range_dict[layer_name] = [torch.ones(num_neuron).to(self.device) * 10000, torch.ones(num_neuron).to(self.device) * -10000]
         self.coverage_dict = {
             'multisec': coverage_multisec_dict
         }
         self.current = 0
 
-    def build(data_loader):
+    def build(self, data_loader):
         print('Building range...')
         for data, *_ in tqdm(data_loader):
             if isinstance(data, tuple):
@@ -538,7 +538,7 @@ class KMNC(Coverage):
 
             index = tuple([torch.LongTensor(list(range(num_neuron))), multisec_output])
             multisec_covered[index] = True
-            multisec_cove_dict[layer_name] = multisec_covered | self.cove_dict['multisec'][layer_name]
+            multisec_cove_dict[layer_name] = multisec_covered | self.coverage_dict['multisec'][layer_name]
         
         return {
             'multisec': multisec_cove_dict
@@ -610,7 +610,7 @@ class SNAC(KMNC):
 
 
 class NBC(KMNC):
-    def init_variable(self):
+    def init_variable(self, hyper=None):
         assert hyper is None
         self.name = 'NBC'
         self.range_dict = {}
@@ -668,7 +668,7 @@ class NBC(KMNC):
 class TKNC(Coverage):
     def init_variable(self, hyper):
         assert hyper is not None
-        self.k = hyper
+        self.k = int(hyper)
         self.coverage_dict = {}
         for (layer_name, layer_size) in self.layer_size_dict.items():
             num_neuron = layer_size[0]

--- a/tool.py
+++ b/tool.py
@@ -146,6 +146,7 @@ class Estimator(object):
         self.CoVariance = torch.zeros(num_class, feature_num, feature_num).to(self.device)
         self.Ave = torch.zeros(num_class, feature_num).to(self.device)
         self.Amount = torch.zeros(num_class).to(self.device)
+        self.CoVarianceInv = torch.zeros(num_class, feature_num, feature_num).to(self.device)
 
     def calculate(self, features, labels=None):
         N = features.size(0)
@@ -225,6 +226,9 @@ class Estimator(object):
         self.Ave = dic['Ave']
         self.CoVariance = dic['CoVariance']
         self.Amount = dic['Amount']
+
+    def invert(self):
+        self.CoVarianceInv = torch.linalg.inv(self.CoVariance)
 
     def transform(self, features, labels):
         CV = self.CoVariance[labels]


### PR DESCRIPTION
As discussed in the issue in 
https://github.com/Yuanyuan-Yuan/NeuraL-Coverage/issues/3
this is the corresponding pull request for precomputing the inverse of the covariance in advance and later just calling the the property. This saves massive amount of time when using MDSC. Also I did some small bugfixes, like typecasting for some hyperparameters as only integer values are allowed for some methods. If desired, I can make a request on a different branch but I think these are only small issues that can be merged with the other issue.